### PR TITLE
A couple of config fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This code is provided on an "AS-IS” basis without warranty of any kind, either
 2. Test Object Credentials
     * Add your TestObject API Key:
     ```
-    $ export TESTOBJECT_API_KEY=<your project's api key>
+    $ export SAUCE_API_KEY=<your project's api key>
     $ export APPIUM_URL=<your project's api key>
         
     ```

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,8 @@ task :default => :spec
 desc "Run Tests on Android"
 task :test_android_device do
   ENV['platformName'] = 'Android'
+  ENV['platformVersion'] = '9'
+  ENV['deviceName'] = 'Google Pixel XL'
   ENV['JUNIT_DIR'] = 'junit_reports/android_device'
 
   Rake::Task[:run_rspec].execute

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,9 @@ RSpec.configure do |config|
   config.before(:each) do |example|
     caps = {
         testobject_api_key: ENV['SAUCE_API_KEY'],
-        deviceName: ENV['platformName'],
+        platformName: ENV['platformName'],
+        platformVersion: ENV['platformVersion'],
+        deviceName: ENV['deviceName'],
         testobject_test_name: example.full_description
     }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
 
   config.before(:each) do |example|
     caps = {
-        testobject_api_key: ENV['TESTOBJECT_API_KEY'],
+        testobject_api_key: ENV['SAUCE_API_KEY'],
         deviceName: ENV['platformName'],
         testobject_test_name: example.full_description
     }
@@ -25,7 +25,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do |example|
-    url = "https://#{ENV['TESTOBJECT_API_KEY']}:#{'blank'}@app.testobject.com/api/rest/v1/appium/session/#{@sessionid}/test"
+    url = "https://#{ENV['SAUCE_API_KEY']}:#{'blank'}@app.testobject.com/api/rest/v1/appium/session/#{@sessionid}/test"
 
     call = {url: url,
             method: :put,


### PR DESCRIPTION
Environment variable `TESTOBJECT_API_KEY` changed to `SAUCE_API_KEY` for parity with other projects.

Config of the Android example updated because i don't think it made sense before.